### PR TITLE
fix hex-to-decimal conversion for numeric argument commands

### DIFF
--- a/eiscp/core.py
+++ b/eiscp/core.py
@@ -219,7 +219,7 @@ def iscp_to_command(iscp_message):
                 return zone_cmds[command]['name'], \
                        zone_cmds[command]['values'][args]['name']
             else:
-                match = re.match('[+-]?[0-9a-f]$', args, re.IGNORECASE)
+                match = re.match('[+-]?[0-9a-f]+$', args, re.IGNORECASE)
                 if match:
                     return zone_cmds[command]['name'], \
                              int(args, 16)

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ f.close()
 
 setup(
     name='onkyo-eiscp',
-    version='0.9.1',
+    version='0.9.2',
     url='https://github.com/miracle2k/onkyo-eiscp',
     license='MIT',
     author='Michael Elsdörfer',


### PR DESCRIPTION
- the hex conversion iscp_to_command() had a typo in the regex,
  causing it to fail and to return hexadecimal strings (as opposed
  to the intended converted int) for hex strings with more than one digit. 
  Very noticable e.g. with the volume commands