### PR TITLE
Correctly handle variable-length line terminators when parsing response

### DIFF
--- a/eiscp/core.py
+++ b/eiscp/core.py
@@ -32,9 +32,16 @@ class ISCPMessage(object):
     @classmethod
     def parse(self, data):
         EOF = '\x1a'
+        TERMINATORS = ['\n', '\r']
         assert data[:2] == '!1'
-        assert data[-1] in [EOF, '\n', '\r']
-        return data[2:-3]
+        eof_offset = -1
+        # EOF can be followed by CR/LF/CR+LF
+        if data[eof_offset] in TERMINATORS:
+          eof_offset -= 1
+          if data[eof_offset] in TERMINATORS:
+            eof_offset -= 1
+        assert data[eof_offset] == EOF
+        return data[2:eof_offset]
 
 
 class eISCPPacket(object):


### PR DESCRIPTION
Previously, the hardcoded -3 assumed EOF+CR+LF line ending; receivers which
sent bare EOF chopped off 2 bytes of the parameters (if any) in the returned
message. e.g. sending listening-mode=query, which previously returned
  LMD (or ('listening-mode', ''))
now correctly returns
  LMD01 (or ('listening-mode', 'direct'))
on such a receiver (e.g. Integra DTR-30.2)