### PR TITLE
Mention onkyo2mqtt in README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -292,6 +292,9 @@ http://code.google.com/p/onkyo-eiscp-remote-windows/
 https://github.com/janten/onkyo-eiscp-remote-mac
     Object-C implementation.
 
+https://github.com/owagner/onkyo2mqtt
+    MQTT connectivity for onkyo-eiscp, adhering to the mqtt-smarthome specification
+
 https://sites.google.com/a/webarts.ca/toms-blog/Blog/new-blog-items/javaeiscp-integraserialcontrolprotocol
     Some Java code. Also deserves credit for providing the official Onkyo
     protocol documentation linked above.


### PR DESCRIPTION
This PR mentions onkyo2mqtt in the "related projects" section of the README.rst file. onkyo2mqtt is a MQTT frontend using onkyo-eiscp, and adheres to the mqtt-smarthome specification.