### PR TITLE
Format script output a little more nicely

### DIFF
--- a/eiscp/core.py
+++ b/eiscp/core.py
@@ -224,16 +224,11 @@ def iscp_to_command(iscp_message):
         command, args = iscp_message[:3], iscp_message[3:]
         if command in zone_cmds:
             if args in zone_cmds[command]['values']:
-                return zone_cmds[command]['name'], \
-                       zone_cmds[command]['values'][args]['name']
+                args = zone_cmds[command]['values'][args]['name']
             else:
-                match = re.match('[+-]?[0-9a-f]+$', args, re.IGNORECASE)
-                if match:
-                    return zone_cmds[command]['name'], \
-                             int(args, 16)
-                else:
-                    return zone_cmds[command]['name'], args
-
+                if re.match('[+-]?[0-9a-f]+$', args, re.IGNORECASE):
+                    args = int(args, 16)
+            return zone_cmds[command]['name'], args
     else:
         raise ValueError(
             'Cannot convert ISCP message to command: %s' % iscp_message)
@@ -341,13 +336,23 @@ class eISCP(object):
         self.command_socket = None
 
     def __repr__(self):
-        if self.info and self.info.get('model_name'):
-            model = self.info['model_name']
-        else:
-            model = 'unknown'
         string = "<%s(%s) %s:%s>" % (
-            self.__class__.__name__, model, self.host, self.port)
+            self.__class__.__name__, self.model_name, self.host, self.port)
         return string
+
+    @property
+    def model_name(self):
+        if self.info and self.info.get('model_name'):
+            return self.info['model_name']
+        else:
+            return 'unknown-model'
+
+    @property
+    def identifier(self):
+        if self.info and self.info.get('identifier'):
+            return self.info['identifier']
+        else:
+            return 'no-id'
 
     @property
     def info(self):

--- a/eiscp/core.py
+++ b/eiscp/core.py
@@ -310,21 +310,21 @@ class eISCP(object):
                 sock.setsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST, 1)
                 sock.bind((ifaddr["addr"], 0))
                 sock.sendto(onkyo_magic, (ifaddr["broadcast"], onkyo_port))
-        
+
                 while True:
                     ready = select.select([sock], [], [], timeout)
                     if not ready[0]:
                         break
                     data, addr = sock.recvfrom(1024)
-        
+
                     info = parse_info(data)
-        
+
                     # Give the user a ready-made receiver instance. It will only
                     # connect on demand, when actually used.
                     receiver = (clazz or eISCP)(addr[0], int(info['iscp_port']))
                     receiver.info = info
                     found_receivers[info["identifier"]]=receiver
-        
+
                 sock.close()
         return found_receivers.values()
 

--- a/eiscp/script.py
+++ b/eiscp/script.py
@@ -48,8 +48,7 @@ def main(argv=sys.argv):
     # List commands
     if options['--discover']:
         for receiver in eISCP.discover(timeout=1):
-            print '%s %s:%s %s' % (
-                receiver.info['model_name'], receiver.host, receiver.port, receiver.info['identifier'])
+            print '%s\t%s:%s\t%s' % (receiver.model_name, receiver.host, receiver.port, receiver.identifier)
         return
 
     # List available commands
@@ -95,10 +94,10 @@ def main(argv=sys.argv):
         if not options['--all']:
             if options['--name']:
                 receivers = [r for r in receivers
-                             if options['--name'] in r.info['model_name']]
+                             if options['--name'] in r.model_name]
             elif options['--id']:
                 receivers = [r for r in receivers
-                             if options['--id'] in r.info['identifier']]
+                             if options['--id'] in r.identifier]
             else:
                 receivers = receivers[:1]
         if not receivers:

--- a/eiscp/script.py
+++ b/eiscp/script.py
@@ -1,7 +1,7 @@
 '''Control Onkyo A/V receivers.
 
 Usage:
-  %(program_name)s [--host <host>] [--port <port>] 
+  %(program_name)s [--host <host>] [--port <port>]
                    [--all] [--name <name>] [--id <identifier>]
                    <command>...
   %(program_name)s --discover


### PR DESCRIPTION
Instead of:

    $ onkyo main.volume=20
    <eISCP(TX-NR646) 192.168.0.16:60128>: MVL14
    (('master-volume', 'volume'), 20)

This prints:

    $ onkyo main.volume=20
    sending to TX-NR646: main.volume=20 (MVL14)
    response: volume = 20

It's noted in one of the commits but `volume` is the only command with multiple names, so the behavior I chose for that was displaying the shortest name. If the response has multiple args, they are printed with commas.

The host is displayed here only if there are multiple devices with the given model name. Could always use the identifier to disambiguate instead if there's any possibility that someone has two of the same model device behind the same address.