### PR TITLE
Add support for ONKYO_HOST and ONKYO_PORT environment variables

### DIFF
--- a/eiscp/core.py
+++ b/eiscp/core.py
@@ -280,6 +280,8 @@ class eISCP(object):
     uses a background thread.
     """
 
+    ONKYO_PORT = 60128
+
     @classmethod
     def discover(cls, timeout=5, clazz=None):
         """Try to find ISCP devices on network.
@@ -287,7 +289,6 @@ class eISCP(object):
         Waits for ``timeout`` seconds, then returns all devices found,
         in form of a list of dicts.
         """
-        onkyo_port = 60128
         onkyo_magic = str(eISCPPacket('!xECNQSTN'))
         # Since due to interface aliasing we may see the same Onkyo device
         # multiple times, we build the list as a dict keyed by the
@@ -309,7 +310,7 @@ class eISCP(object):
                 sock.setblocking(0)   # So we can use select()
                 sock.setsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST, 1)
                 sock.bind((ifaddr["addr"], 0))
-                sock.sendto(onkyo_magic, (ifaddr["broadcast"], onkyo_port))
+                sock.sendto(onkyo_magic, (ifaddr["broadcast"], eISCP.ONKYO_PORT))
 
                 while True:
                     ready = select.select([sock], [], [], timeout)

--- a/eiscp/script.py
+++ b/eiscp/script.py
@@ -11,7 +11,7 @@ Usage:
 Selecting the receiver:
 
   --host, -t <host>     Connect to this host
-  --port, -p <port>     Connect to this port [default: 60128]
+  --port, -p <port>     Connect to this port
   --all, -a             Discover receivers, send to all found
   --name, -n <name>     Discover receivers, send to those matching name.
   --id, -i <id>         Discover receivers, send to those matching identifier.
@@ -87,8 +87,10 @@ def main(argv=sys.argv):
         return
 
     # Determine the receivers the command should run on
-    if options['--host']:
-        receivers = [eISCP(options['--host'], int(options['--port']))]
+    host = options.get('--host') or os.environ.get('ONKYO_HOST', None)
+    port = int(options.get('--port') or os.environ.get('ONKYO_PORT', eISCP.ONKYO_PORT))
+    if host:
+        receivers = [eISCP(host, port)]
     else:
         receivers = eISCP.discover(timeout=1)
         if not options['--all']:


### PR DESCRIPTION
I know what IP my receiver is on and don't want to run discovery every time. With this, i can set an environment variable (much more convenient to do for multiple users on the same machine than an alias) and then just run `onkyo` instead of `onkyo --host HOST`.

Port can already be set the same way, but I don't need to set it. This means that the default value of the port isn't going to show up in the help text; instead, it's a constant in the eISCP class, so now it doesn't need to be repeated between the two files.