### PR TITLE
Add verbose/quiet options

### DIFF
--- a/eiscp/script.py
+++ b/eiscp/script.py
@@ -2,8 +2,8 @@
 
 Usage:
   %(program_name)s [--host <host>] [--port <port>]
-                   [--all] [--name <name>] [--id <identifier>]
-                   <command>...
+  %(prog_n_space)s [--all] [--name <name>] [--id <identifier>]
+  %(prog_n_space)s <command>...
   %(program_name)s --discover
   %(program_name)s --help-commands [<zone> <command>]
   %(program_name)s -h | --help
@@ -23,9 +23,9 @@ and uses the first one found.
   --help-commands       List available commands.
 
 Examples:
-  onkyo power:on source:pc volume:75
+  %(program_name)s power=on source=pc volume=75
     Turn receiver on, select "PC" source, set volume to 75.
-  onkyo zone2.power:standby
+  %(program_name)s zone2.power=standby
     To execute a command for zone that isn't the main one.
 '''
 
@@ -38,7 +38,8 @@ import commands
 
 # Automatically replace %(program_name)s with the current program name in the
 # documentation.
-__doc__ %= dict(program_name=sys.argv[0])
+program_name = os.path.basename(sys.argv[0])
+__doc__ %= {'program_name': program_name, 'prog_n_space': ' ' * len(program_name)}
 
 
 def main(argv=sys.argv):

--- a/eiscp/script.py
+++ b/eiscp/script.py
@@ -3,7 +3,7 @@
 Usage:
   %(program_name)s [--host <host>] [--port <port>]
   %(prog_n_space)s [--all] [--name <name>] [--id <identifier>]
-  %(prog_n_space)s [--verbose | -v]... <command>...
+  %(prog_n_space)s [--verbose | -v]... [--quiet | -q]... <command>...
   %(program_name)s --discover
   %(program_name)s --help-commands [<zone> <command>]
   %(program_name)s -h | --help
@@ -16,6 +16,7 @@ Selecting the receiver:
   --name, -n <name>     Discover receivers, send to those matching name.
   --id, -i <id>         Discover receivers, send to those matching identifier.
   --verbose, -v         Show commands sent and additional info
+  --quiet, -q           Don't include receiver name in response
 
 If none of these options is given, the program searches for receivers,
 and uses the first one found.
@@ -123,7 +124,10 @@ def main(argv=sys.argv):
                     if options['--verbose'] >= 1:
                         print 'sending to %s: %s' % (name, command)
                     response = receiver.raw(command)
-                    print 'response: %s' % response
+                    if options['--quiet'] >= 1:
+                        print response
+                    else
+                        print '%s: %s' % (name, response)
                 else:
                     if options['--verbose'] >= 1:
                         print 'sending to: %s (%s)' % (name, command, command_to_iscp(command))
@@ -136,7 +140,10 @@ def main(argv=sys.argv):
                         cmd_name = min(cmd_name, key=len)
                     if isinstance(args, tuple):
                         args = ','.join(args)
-                    print '%s: %s = %s' % (name, cmd_name, args)
+                    if options['--quiet'] >= 1:
+                        print '%s = %s' % (name, cmd_name, args)
+                    else:
+                        print '%s: %s = %s' % (name, cmd_name, args)
 
 
 def run():

--- a/eiscp/script.py
+++ b/eiscp/script.py
@@ -3,7 +3,7 @@
 Usage:
   %(program_name)s [--host <host>] [--port <port>]
   %(prog_n_space)s [--all] [--name <name>] [--id <identifier>]
-  %(prog_n_space)s <command>...
+  %(prog_n_space)s [--verbose | -v]... <command>...
   %(program_name)s --discover
   %(program_name)s --help-commands [<zone> <command>]
   %(program_name)s -h | --help
@@ -15,6 +15,7 @@ Selecting the receiver:
   --all, -a             Discover receivers, send to all found
   --name, -n <name>     Discover receivers, send to those matching name.
   --id, -i <id>         Discover receivers, send to those matching identifier.
+  --verbose, -v         Show commands sent and additional info
 
 If none of these options is given, the program searches for receivers,
 and uses the first one found.
@@ -119,11 +120,13 @@ def main(argv=sys.argv):
                 name += '@' + receiver.host
             for command in to_execute:
                 if command.isupper() and command.isalnum():
-                    print 'sending to %s: %s' % (name, command)
+                    if options['--verbose'] >= 1:
+                        print 'sending to %s: %s' % (name, command)
                     response = receiver.raw(command)
                     print 'response: %s' % response
                 else:
-                    print 'sending to %s: %s (%s)' % (name, command, command_to_iscp(command))
+                    if options['--verbose'] >= 1:
+                        print 'sending to: %s (%s)' % (name, command, command_to_iscp(command))
                     try:
                         cmd_name, args = receiver.command(command)
                     except ValueError, e:
@@ -133,7 +136,7 @@ def main(argv=sys.argv):
                         cmd_name = min(cmd_name, key=len)
                     if isinstance(args, tuple):
                         args = ','.join(args)
-                    print 'response: %s = %s' % (cmd_name, args)
+                    print '%s: %s = %s' % (name, cmd_name, args)
 
 
 def run():


### PR DESCRIPTION
This lets you control the amount of stuff printed with --verbose and --quiet options. By default, it prints a little less, just the responses. In particular, I find `-qq` super useful for scripting. Here is a demonstration of all the possible output levels with a volume query command:

```
$ onkyo volume=query
TX-NR646: volume = 20
$ onkyo -v volume=query
sending to TX-NR646: volume=query
TX-NR646: volume = 20
$ onkyo -vv volume=query
sending to TX-NR646: volume=query (MVLQSTN)
TX-NR646: volume = 20 (MVL14)
$ onkyo -q volume=query
volume = 20
$ onkyo -qq volume=query
20

$ onkyo MVLQSTN
TX-NR646: MVL14
$ onkyo -v MVLQSTN
sending to TX-NR646: MVLQSTN
TX-NR646: MVL14
$ onkyo -vv MVLQSTN
sending to TX-NR646: MVLQSTN ((('master-volume', 'volume'), 'query'))
TX-NR646: MVL14 (volume = 20)
$ onkyo -q MVLQSTN
MVL14
# for raw commands, -qq outputs the same as -q
```