### PR TITLE
fix commands for SLI23 : select source CD or TV/CD

### DIFF
--- a/eiscp/commands.py
+++ b/eiscp/commands.py
@@ -346,7 +346,7 @@ COMMANDS = OrderedDict([('main', OrderedDict([('PWR', {'values': OrderedDict([('
      'description': 'sets TAPE(1), TV/TAPE'}),
     ('21', {'name': 'tape2', 'description': 'sets TAPE2'}),
     ('22', {'name': 'phono', 'description': 'sets PHONO'}),
-    ('23', {'name': ('cd', 'tv', 'cd'), 'description': 'sets CD, TV/CD'}),
+    ('23', {'name': ('cd', 'tv/cd'), 'description': 'sets CD, TV/CD'}),
     ('24', {'name': 'fm', 'description': 'sets FM'}),
     ('25', {'name': 'am', 'description': 'sets AM'}),
     ('\u201c26\u201d', {'name': 'tuner', 'description': 'sets TUNER'}),


### PR DESCRIPTION
earlier model of onkyo don't have a TV source or CD source they have only a "TV/CD" source so I think it makes sense for them to query "TV/CD" or "CD" directly...