### PR TITLE
Make stereo wrap around command distinct to unbreak stereo command

### DIFF
--- a/commands/main/LMD.yaml
+++ b/commands/main/LMD.yaml
@@ -580,7 +580,7 @@ values:
   STEREO:
     description: sets Listening Mode Wrap-Around Up
     models: *id001
-    name: stereo
+    name: stereo-wrap
   SURR:
     description: sets Listening Mode Wrap-Around Up
     models: *id001


### PR DESCRIPTION
The stereo command for main is currently broken as it the wrap-around stereo command overloads the distinct one. This patch makes renames the wrap-around version to fix the distinct one.