### PR TITLE
Add a timeout to socket.connect

### DIFF
--- a/eiscp/core.py
+++ b/eiscp/core.py
@@ -296,6 +296,7 @@ class eISCP(object):
     uses a background thread.
     """
     ONKYO_PORT = 60128
+    CONNECT_TIMEOUT = 5
 
     @classmethod
     def discover(cls, timeout=5, clazz=None):
@@ -399,6 +400,7 @@ class eISCP(object):
     def _ensure_socket_connected(self):
         if self.command_socket is None:
             self.command_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            self.command_socket.settimeout(self.CONNECT_TIMEOUT)
             self.command_socket.connect((self.host, self.port))
             self.command_socket.setblocking(0)
 


### PR DESCRIPTION
Sets a timeout on the socket object prior to calling connect. This helps the case where one is sending a command to an IP, there is a device listening at that IP, but not the receiver. 

In testing this scenario, I've seen a wait of about 2 minutes without setting a timeout.

I'm fairly new to this codebase and wasn't sure if the timeout should be more configurable, but this seems like a bit of an edge case so figured this simple way of setting it (basically hardcoding to 5 seconds) wouldn't be bad.