### PR TITLE
Fix checking if command is RAW

### DIFF
--- a/eiscp/script.py
+++ b/eiscp/script.py
@@ -36,6 +36,7 @@ Examples:
 import sys
 import os
 import docopt
+import re
 
 from .core import eISCP, command_to_iscp, iscp_to_command
 from . import commands
@@ -116,13 +117,14 @@ def main(argv=sys.argv):
 
     # Execute commands
     model_names = [r.model_name for r in receivers]
+    regex = re.compile('^[A-Z]+[\+\-]*([0-9]*[A-Z]*)*$')
     for receiver in receivers:
         with receiver:
             name = receiver.model_name
             if model_names.count(receiver.model_name) > 1:
                 name += '@' + receiver.host
             for command in to_execute:
-                raw = command.isupper() and command.isalnum()
+                raw = bool(regex.search(command))
                 log = Log(name, options, raw)
                 log.log_command(command)
                 if raw:


### PR DESCRIPTION
Originally, a command was determined to be raw if it was all uppercase and only alphanumerical. This breaks any command that contains a different character such as setting the temporary subwoofer level with SWL+05. A regular expression now checks if a command is all uppercase, contains `-` or `+`, and if it is alphanumerical. To achieve support for True/False, the entire string is checked using `^` and `$`. Thus, a command will be seen as raw if it starts with 1 or more uppercase letters, contains 0 or more `-` or `+` and ends with 0 or more numbers or uppercase letters in any combination.