### PR TITLE
Properly handle integers and negative integers

### DIFF
--- a/commands/main/LMD.yaml
+++ b/commands/main/LMD.yaml
@@ -198,6 +198,7 @@ values:
     - TX-RZ620
     - TX-RZ710
     - TX-RZ720
+    - TX-RZ730
     - TX-RZ800
     - TX-RZ810
     - TX-RZ820

--- a/commands/main/LMD.yaml
+++ b/commands/main/LMD.yaml
@@ -604,7 +604,7 @@ values:
   STEREO:
     description: sets Listening Mode Wrap-Around Up
     models: *id001
-    name: stereo
+    name: ster
   SURR:
     description: sets Listening Mode Wrap-Around Up
     models: *id001

--- a/eiscp-commands.yaml
+++ b/eiscp-commands.yaml
@@ -1868,7 +1868,7 @@ main:
         description: sets Listening Mode Wrap-Around Up
         models: set1
       STEREO:
-        name: stereo
+        name: ster
         description: sets Listening Mode Wrap-Around Up
         models: set1
       QSTN:

--- a/eiscp/commands.py
+++ b/eiscp/commands.py
@@ -697,7 +697,7 @@ COMMANDS = OrderedDict([('main', OrderedDict([('PWR', {'values': OrderedDict([('
      'description': 'sets Listening Mode Wrap-Around Up'}),
     ('SURR', {'name': 'surr',
      'description': 'sets Listening Mode Wrap-Around Up'}),
-    ('STEREO', {'name': 'stereo',
+    ('STEREO', {'name': 'ster',
      'description': 'sets Listening Mode Wrap-Around Up'}),
     ('QSTN', {'name': 'query', 'description': 'gets The Listening Mode'})]),
    'name': 'listening-mode',

--- a/eiscp/core.py
+++ b/eiscp/core.py
@@ -205,35 +205,37 @@ def command_to_iscp(command, arguments=None, zone=None):
     # (setting tuning frequency). In some cases, we might imagine
     # providing the user an API with multiple arguments (TODO: not
     # currently supported).
-    if type(arguments) == str:
+    if type(arguments) is list:
         argument = arguments[0]
     else:
         argument = arguments
 
         # 1. Consider if there is a alias, e.g. level-up for UP.
-        try:
-            value = commands.VALUE_MAPPINGS[group][prefix][argument]
-        except KeyError:
-            # 2. See if we can match a range or pattern
-            for possible_arg in commands.VALUE_MAPPINGS[group][prefix]:
-                if type(argument) == int or (type(argument) == str and argument.isdigit() is True):
-                    if isinstance(possible_arg, ValueRange):
-                        if int(argument) in possible_arg:
-                            # We need to send the format "FF", hex() gives us 0xff
-                            value = hex(int(argument))[2:].zfill(2).upper()
-                            if prefix == 'SWL':
-                                if value == '00':
-                                    value = '0' + value
-                                elif value[0] != 'X':
-                                    value = '+' + value
-                                elif value[0] == 'X':
-                                    value = '-' + value[1:]
-                            break
+    try:
+        value = commands.VALUE_MAPPINGS[group][prefix][argument]
+    except KeyError:
+        # 2. See if we can match a range or pattern
+        for possible_arg in commands.VALUE_MAPPINGS[group][prefix]:
+            if type(argument) is int or (type(argument) is str and argument.lstrip("-").isdigit() is True):
+                if isinstance(possible_arg, ValueRange):
+                    if int(argument) in possible_arg:
+                        # We need to send the format "FF", hex() gives us 0xff
+                        value = hex(int(argument))[2:].zfill(2).upper()
+                        if prefix == 'SWL':
+                            if value == '00':
+                                value = '0' + value
+                            elif value[0] != 'X':
+                                value = '+' + value
+                            elif value[0] == 'X':
+                                if len(value) == 2:
+                                    value = '-' + '0' + value[1:]
+                                value = '-' + value[1:]
+                        break
 
-                # TODO: patterns not yet supported
-                else:
-                    raise ValueError('"{}" is not a valid argument for command '
-                                 '"{}" in zone "{}"'.format(argument, command, zone))
+            # TODO: patterns not yet supported
+            else:
+                raise ValueError('"{}" is not a valid argument for command '
+                                '"{}" in zone "{}"'.format(argument, command, zone))
 
     return '{}{}'.format(prefix, value)
 

--- a/eiscp/core.py
+++ b/eiscp/core.py
@@ -221,7 +221,7 @@ def command_to_iscp(command, arguments=None, zone=None):
                     if int(argument) in possible_arg:
                         # We need to send the format "FF", hex() gives us 0xff
                         value = hex(int(argument))[2:].zfill(2).upper()
-                        if prefix == 'SWL':
+                        if prefix == 'SWL' or prefix == 'CTL':
                             if value == '00':
                                 value = '0' + value
                             elif value[0] != 'X':

--- a/eiscp/core.py
+++ b/eiscp/core.py
@@ -221,6 +221,13 @@ def command_to_iscp(command, arguments=None, zone=None):
                         if int(argument) in possible_arg:
                             # We need to send the format "FF", hex() gives us 0xff
                             value = hex(int(argument))[2:].zfill(2).upper()
+                            if prefix == 'SWL':
+                                if value == '00':
+                                    value = '0' + value
+                                elif value[0] != 'X':
+                                    value = '+' + value
+                                elif value[0] == 'X':
+                                    value = '-' + value[1:]
                             break
 
                 # TODO: patterns not yet supported

--- a/eiscp/core.py
+++ b/eiscp/core.py
@@ -205,25 +205,28 @@ def command_to_iscp(command, arguments=None, zone=None):
     # (setting tuning frequency). In some cases, we might imagine
     # providing the user an API with multiple arguments (TODO: not
     # currently supported).
-    argument = arguments[0]
+    if type(arguments) == str:
+        argument = arguments[0]
+    else:
+        argument = arguments
 
-    # 1. Consider if there is a alias, e.g. level-up for UP.
-    try:
-        value = commands.VALUE_MAPPINGS[group][prefix][argument]
-    except KeyError:
-        # 2. See if we can match a range or pattern
-        for possible_arg in commands.VALUE_MAPPINGS[group][prefix]:
-            if argument.isdigit():
-                if isinstance(possible_arg, ValueRange):
-                    if int(argument) in possible_arg:
-                        # We need to send the format "FF", hex() gives us 0xff
-                        value = hex(int(argument))[2:].zfill(2).upper()
-                        break
+        # 1. Consider if there is a alias, e.g. level-up for UP.
+        try:
+            value = commands.VALUE_MAPPINGS[group][prefix][argument]
+        except KeyError:
+            # 2. See if we can match a range or pattern
+            for possible_arg in commands.VALUE_MAPPINGS[group][prefix]:
+                if type(argument) == int or (type(argument) == str and argument.isdigit() is True):
+                    if isinstance(possible_arg, ValueRange):
+                        if int(argument) in possible_arg:
+                            # We need to send the format "FF", hex() gives us 0xff
+                            value = hex(int(argument))[2:].zfill(2).upper()
+                            break
 
-            # TODO: patterns not yet supported
-        else:
-            raise ValueError('"{}" is not a valid argument for command '
-                             '"{}" in zone "{}"'.format(argument, command, zone))
+                # TODO: patterns not yet supported
+                else:
+                    raise ValueError('"{}" is not a valid argument for command '
+                                 '"{}" in zone "{}"'.format(argument, command, zone))
 
     return '{}{}'.format(prefix, value)
 

--- a/eiscp/script.py
+++ b/eiscp/script.py
@@ -36,6 +36,7 @@ Examples:
 import sys
 import os
 import docopt
+import re
 
 from .core import eISCP, command_to_iscp, iscp_to_command
 from . import commands
@@ -116,13 +117,14 @@ def main(argv=sys.argv):
 
     # Execute commands
     model_names = [r.model_name for r in receivers]
+    regex = re.compile('^[A-Z]+[\+\-]*([0-9]*[A-Z]*)*$')
     for receiver in receivers:
         with receiver:
             name = receiver.model_name
             if model_names.count(receiver.model_name) > 1:
                 name += '@' + receiver.host
             for command in to_execute:
-                raw = command.isupper() and command.isalnum()
+                raw = bool(regex.search(command))
                 log = Log(name, options, raw)
                 log.log_command(command)
                 if raw:

--- a/eiscp/utils.py
+++ b/eiscp/utils.py
@@ -10,7 +10,7 @@ class ValueRange(object):
         self.start = start
         self.end = end
 
-        self._range = tuple(range(start, end))
+        self._range = tuple(range(start, end + 1))
 
     def __contains__(self, value):
         return value in self._range


### PR DESCRIPTION
While trying to set the subwoofer temporary level I noticed a few oddities in the handling of arguments. 
` onkyo --host 192.168.xxx.xxx volume=50` would work
`onkyo --host 192.168.xxx.xxx subwoofer-temporary-level=query` would work
`onkyo --host 192.168.xxx.xxx subwoofer-temporary-level=UP/DOWN` would not work
`onkyo --host 192.168.xxx.xxx subwoofer-temporary-level=24` would also not work. 

Along with that, sending raw commands would also not work, such as:
`onkyo --host 192.168.xxx.xxx SWL+05`

The issue with sending RAW commands was caused by:
https://github.com/miracle2k/onkyo-eiscp/blob/fdbad74dc5fb959f9b653e21f45b8489e5bf8140/eiscp/script.py#L125
Which would not pass values that contain a `+` or `-` in them. This was fixed by using a regex instead. 

Next, sending a command in the format `receiver.command('subwoofer-temporary-level', 23, 'main')` would not work for both subwoofer-temporary-level and master-volume. This was due to all arguments being handled as lists rather than checking if the argument is a list or an integer. 

Another small issue was that ValueRange would not contain the last value in the range, preventing setting the volume to the actual maximum. 

The final issue was the formatting of the hexadecimal command, which for subwoofer-temporary-level could be positive and negative. Therefor, the range of values is -1E...000...+18 for -15 dB...0 dB...+12 dB (similar to how TFR handles values). To correct for this, if the command prefix is determined to be `SWL`, an extra `0` will be added for `00` values. Positive values will be prefixed with `+`, single digit negative values are prefixed with `-0` (-1 to -15) and double digit negative values are prefixed with `-`. 

This pull request solves https://github.com/miracle2k/onkyo-eiscp/issues/127 and https://github.com/miracle2k/onkyo-eiscp/issues/104. It can easily be extended to other commands such as center channel temporary level by adding `CTL` to the prefix check. I have not done this yet, as I would like to investigate what all the commands are that would need to be handled this way. For example, the temporary channel level (which my receiver does not seem to have) will also need these positive and negative dB values. 