### PR TITLE
Add parsing for NRI

### DIFF
--- a/eiscp/utils.py
+++ b/eiscp/utils.py
@@ -14,3 +14,19 @@ class ValueRange(object):
 
     def __contains__(self, value):
         return value in self._range
+
+
+def format_nri_list(data):
+    """Return NRI lists as dict with names or ids as the key."""
+    if not data:
+        return None
+    info = {}
+    for item in data:
+        if item.get("name") is not None:
+            key = item.pop("name")
+        elif item.get("id") is not None:
+            key = item.pop("id")
+        else:
+            return None
+        info[key] = item
+    return info

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     long_description=long_description,
     packages = find_packages(exclude=('tests*',)),
     entry_points="""[console_scripts]\nonkyo = eiscp.script:run\n""",
-    install_requires=['docopt>=0.4.1', 'netifaces'],
+    install_requires=['docopt>=0.4.1', 'netifaces', 'xmltodict>=0.12.0'],
     platforms='any',
     classifiers=[
         'Topic :: System :: Networking',


### PR DESCRIPTION
Tested with Onkyo: HT-R695.

Wanted to get a list of available input sources for my receiver. Noticed that the sources are present in the NRI XML string returned using `eISCP.command("dock.receiver-information=query")`. Came up with this implementation to parse the string at high-level. I do not have any other receivers to test this.