### PR TITLE
Detect when socket has been disconnected to force a reconnection

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,6 @@
+1.2.9 (2024-02-07)
+    - Fix disconnected socket in async API
+
 1.2.8 (2019-11-09)
     - Added HDMI-CEC TV control support via CTV command. See 'onkyo --help-commands main ctv' for possible values.
 

--- a/eiscp/core.py
+++ b/eiscp/core.py
@@ -512,6 +512,10 @@ class eISCP(object):
         ready = select.select([self.command_socket], [], [], timeout or 0)
         if ready[0]:
             header_bytes = self.command_socket.recv(16)
+            if len(header_bytes) == 0:
+                # We have very likely been disconnected
+                eISCP.disconnect(self)
+                return None
             header = eISCPPacket.parse_header(header_bytes)
             body = b''
             while len(body) < header.data_size:

--- a/setup.py
+++ b/setup.py
@@ -11,13 +11,13 @@ long_description = f.read().strip()
 f.close()
 
 setup(
-    name='onkyo-eiscp',
-    version='1.2.8',
-    url='https://github.com/miracle2k/onkyo-eiscp',
+    name='dannytrigo-onkyo-eiscp',
+    version='1.2.9',
+    url='https://github.com/dannytrigo/onkyo-eiscp',
     license='MIT',
     author='Michael Elsdörfer',
     author_email='michael@elsdoerfer.com',
-    description='Control Onkyo receivers over ethernet.',
+    description='Control Onkyo receivers over ethernet. (dannytrigo fork for bugfix)',
     long_description=long_description,
     packages = find_packages(exclude=('tests*',)),
     entry_points="""[console_scripts]\nonkyo = eiscp.script:run\n""",


### PR DESCRIPTION
Using the async API with the poll loop, it seems my socket gets disconnected at some point and then recv returns 0 bytes, and the header parsing fails. This forces a disconnect so that the loop can reopen the socket