### PR TITLE
Add ability to retrieve zone from decoded command

### DIFF
--- a/eiscp/core.py
+++ b/eiscp/core.py
@@ -242,27 +242,27 @@ def command_to_iscp(command, arguments=None, zone=None):
     return '{}{}'.format(prefix, value)
 
 
-def iscp_to_command(iscp_message):
-    for zone, zone_cmds in commands.COMMANDS.items():
-        # For now, ISCP commands are always three characters, which
-        # makes this easy.
-        command, args = iscp_message[:3], iscp_message[3:]
-        if command in zone_cmds:
-            if args in zone_cmds[command]['values']:
-                return zone_cmds[command]['name'], \
-                       zone_cmds[command]['values'][args]['name']
-            else:
-                match = re.match('[+-]?[0-9a-f]+$', args, re.IGNORECASE)
-                if match:
-                    return zone_cmds[command]['name'], \
-                             int(args, 16)
+def iscp_to_command(iscp_message, with_zone=False):
+    def __iscp_to_command(iscp_message):
+        for zone, zone_cmds in commands.COMMANDS.items():
+            # For now, ISCP commands are always three characters, which
+            # makes this easy.
+            command, args = iscp_message[:3], iscp_message[3:]
+            if command in zone_cmds:
+                if args in zone_cmds[command]['values']:
+                    return zone, zone_cmds[command]['name'], \
+                           zone_cmds[command]['values'][args]['name']
                 else:
-                    return zone_cmds[command]['name'], args
-
-    else:
-        raise ValueError(
-            'Cannot convert ISCP message to command: {}'.format(iscp_message))
-
+                    match = re.match('[+-]?[0-9a-f]+$', args, re.IGNORECASE)
+                    if match:
+                        return zone, zone_cmds[command]['name'], int(args, 16)
+                    else:
+                        return zone, zone_cmds[command]['name'], args
+        else:
+            raise ValueError(
+                'Cannot convert ISCP message to command: {}'.format(iscp_message))
+    zone, ret_cmd, args = __iscp_to_command(iscp_message)
+    return (zone, ret_cmd, args) if with_zone else (ret_cmd, args)
 
 def filter_for_message(getter_func, msg):
     """Helper that calls ``getter_func`` until a matching message

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,14 +1,19 @@
 from eiscp.core import iscp_to_command, command_to_iscp
+from unittest import TestCase
 
-
-class TestIscpToCommand:
+class TestIscpToCommand(TestCase):
     def test(self):
-        assert iscp_to_command('MVL') == ('master-volume', '')
+        self.assertEqual(('master-volume', ''), iscp_to_command('MVL'))
 
+    def test_with_zone(self):
+        self.assertEqual(('main', 'audio-muting', ''), iscp_to_command('AMT', True))
+        self.assertEqual(('zone2', 'muting', ''), iscp_to_command('ZMT', True))
+        self.assertEqual(('zone3', 'muting', ''), iscp_to_command('MT3', True))
+        self.assertEqual(('zone4', 'muting', ''), iscp_to_command('MT4', True))
 
-class TestCommandToIscp:
+class TestCommandToIscp(TestCase):
     def test(self):
-        assert command_to_iscp('main.system-power=standby') == 'PWR00'
+        self.assertEqual('PWR00', command_to_iscp('main.system-power=standby'))
 
     def test_argument_aliases(self):
-        assert command_to_iscp('main.system-power=off') == 'PWR00'
+        self.assertEqual('PWR00', command_to_iscp('main.system-power=off'))


### PR DESCRIPTION
When using the async API and receiving a command, if you decode it you are sometimes left with a command without knowing which zone it was for.
This adds the ability to get the zone with the decoding, in a backwards compatible way