### PR TITLE
Add group_with function for multiroom audio / flareconnect

### DIFF
--- a/eiscp/core.py
+++ b/eiscp/core.py
@@ -275,6 +275,9 @@ def filter_for_message(getter_func, msg):
         # It seems ISCP commands are always three characters.
         if candidate and candidate[:3] == msg[:3]:
             return candidate
+        elif candidate and candidate[:3] == 'MDI' and msg[:3] == 'MGS':
+            # the MGS command for grouping multiroom audio, returns an MDI message, not MGS
+            return candidate
 
         # exception for HDMI-CEC commands (CTV) since they don't provide any response/confirmation
         if "CTV" in msg[:3]:
@@ -563,6 +566,25 @@ class eISCP(object):
     def power_off(self):
         """Turn the receiver power off."""
         return self.command('power', 'off')
+
+    def group_with(self, otherIDs=[]):
+        """Create a multiroom audio / flareconnect group with the supplied device IDs.
+        Calling this without arguments or an empty list stops the multiroom audio / flareconnect group.
+        Calling this method twice with the same arguments does not generate a response from the receiver, thus causing a timeout on the message."""
+        if otherIDs:
+            # check if the supplied deviceIDs are all strings
+            for ID in otherIDs:
+                if type(ID) != str:
+                    raise ValueError('group_with needs a list object, with each device identifier as a string')
+            # construct a MGS message with a list of the device IDs
+            message='MGS<mgs zone="1"><groupid>1</groupid><maxdelay>500</maxdelay><devices>' + \
+                '<device id="%s" zoneid="1"/>'%(self.identifier) + \
+                ''.join(['<device id="%s" zoneid="1"/>'%(ID) for ID in otherIDs]) + \
+                '</devices></mgs>'
+        else:
+            # No other devices specified. Create an empty group, which stops the multiroom audio / flareconnect
+            message='MGS<mgs zone="1"><groupid>0</groupid></mgs>'
+        return self.raw(message)
 
     def get_nri(self):
         """Return NRI info as dict."""

--- a/eiscp/script.py
+++ b/eiscp/script.py
@@ -6,6 +6,7 @@ Usage:
   %(prog_n_space)s [--verbose | -v]... [--quiet | -q]... <command>...
   %(program_name)s --discover
   %(program_name)s [--host <host>] [--group_with <otherhost> ...] 
+  %(program_name)s [--host <host>] [--grouped_with] 
   %(program_name)s --help-commands [<zone> <command>]
   %(program_name)s -h | --help
 
@@ -120,6 +121,32 @@ def main(argv=sys.argv):
 
     if options['--group_with']:
         receivers[0].group_with(options['<otherhost>'])
+
+    if options['--grouped_with']:
+        groupdata = receivers[0].grouped_with()
+        if groupdata:
+            # get a list of the active groups and their groupid. Normally this is only a single item
+            groups = set([dev["groupid"] for dev in groupdata])
+            for group in groups:
+                # find the source
+                source = [ dev for dev in groupdata if dev["groupid"] == group and dev["role"] == "src" ]
+                if source:
+                    source = source[0]
+                else:
+                    print("failed to detect the source for groupid %s" %(group))
+                    print(groupdata)
+                    return
+                destinations = [ dev for dev in groupdata if dev["groupid"] == group and dev["role"] == "dst" ]
+                if destinations:
+                    pass
+                else:
+                    print("failed to detect the destinations for groupid %s" %(group))
+                    print(groupdata)
+                    return
+                print("Multiroom audio group active with groupid %s" %(group))
+                print("source: %s on address: %s" %(source["model_name"], source["host"]))
+                for destination in destinations:
+                    print("destination: %s on address: %s" %(destination["model_name"], destination["host"]))
 
     # List of commands to execute - deal with special shortcut case
     to_execute = options['<command>']

--- a/eiscp/script.py
+++ b/eiscp/script.py
@@ -5,6 +5,7 @@ Usage:
   %(prog_n_space)s [--all] [--name <name>] [--id <identifier>]
   %(prog_n_space)s [--verbose | -v]... [--quiet | -q]... <command>...
   %(program_name)s --discover
+  %(program_name)s [--host <host>] [--group_with <otherhost> ...] 
   %(program_name)s --help-commands [<zone> <command>]
   %(program_name)s -h | --help
 
@@ -31,6 +32,11 @@ Examples:
     Turn receiver on, select "PC" source, set volume to 75.
   %(program_name)s zone2.power=standby
     To execute a command for zone that isn't the main one.
+  %(program_name)s --host 192.168.1.15 --group_with "0009B0E4B723" "0009B0E4B724"
+    Setup multiroom audio using Flareconnect. The <host> receiver is source, all receiver IDs supplied for <otherhost> join the <host> in a Flareconnect group.
+    Use the --discover option to get the receiver IDs.
+  %(program_name)s --host 192.168.1.15 --group_with
+    Stop the multiroom audio group / flareconnect.
 '''
 
 import sys
@@ -111,6 +117,9 @@ def main(argv=sys.argv):
         if not receivers:
             print('No receivers found.')
             return 1
+
+    if options['--group_with']:
+        receivers[0].group_with(options['<otherhost>'])
 
     # List of commands to execute - deal with special shortcut case
     to_execute = options['<command>']


### PR DESCRIPTION
I've added a group_with function to the eISCP class, for easier setup of multiroom audio (also known as Flareconnect). Calling this function on a receiver, and supplying it with a list of other receiver deviceIDs will craft a message that sets up a zone for synchronized audio across multiple devices. 

special thanks go to @bendamat who pointed me in the right direction in https://github.com/miracle2k/onkyo-eiscp/issues/158